### PR TITLE
Remove https://github.com/gocql/gocql

### DIFF
--- a/docs/repos.yaml
+++ b/docs/repos.yaml
@@ -81,7 +81,6 @@ list:
   - repo: "https://github.com/CrowdStrike/go-restful-openapi"
   - repo: "https://github.com/CrowdStrike/go_kafka_client"
   - repo: "https://github.com/CrowdStrike/gocelery"
-  - repo: "https://github.com/CrowdStrike/gocql"
   - repo: "https://github.com/CrowdStrike/gofalcon"
   - repo: "https://github.com/CrowdStrike/golang-driver"
   - repo: "https://github.com/CrowdStrike/golog"


### PR DESCRIPTION
Spoke with Marcus King who created the initial fork. It's no longer needed and we did not submit patches upstream. Repo was removed from the CRWD org.