### PR TITLE
Update hero image location

### DIFF
--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -5,7 +5,7 @@ permalink: /
 layout: home
 
 hero:
-  image: /community/assets/img/crwd-banner-01.png
+  image: assets/img/crwd-banner-01.png
   callout:
     alt: "Featured Project:"
     text: gofalcon


### PR DESCRIPTION
Now that we've an official domain (opensource.crowdstrike.com) vs crowdstrike.github.io/community, we need to revert the hero img location.